### PR TITLE
Changed Size of Online-Status-Dots @user-avatar

### DIFF
--- a/public/assets/i18n/de.json
+++ b/public/assets/i18n/de.json
@@ -5,6 +5,9 @@
         "logout": "Log out",
         "save": "Speichern"
     },
+    "add-people": {
+        "headline": "Leute hinzufügen"
+    },
     "avatar-bar": {
         "open": "Gruppenmitglieder verwalten. Aktuelle Gesamtmitglieder: {{amount}}"
     },

--- a/src/app/shared/components/chat/add-people/add-people.component.html
+++ b/src/app/shared/components/chat/add-people/add-people.component.html
@@ -1,0 +1,4 @@
+<section class="add-people-box box--floating" [ngStyle]="curvedEdge ? {} : {'border-top-right-radius' : '0px'}">
+    <app-icon iconName="close" class="close-btn icon--hoverable" suffix="svg"></app-icon>
+    <h3>Leute hinzufügen</h3>
+</section>

--- a/src/app/shared/components/chat/add-people/add-people.component.scss
+++ b/src/app/shared/components/chat/add-people/add-people.component.scss
@@ -1,0 +1,12 @@
+@use "./../../../scss/abstracts/" as *;
+@use "./../../../scss/boxes" as *;
+@use './../../../scss/icons' as *;
+
+.add-people-box {
+    position: relative;
+    .close-btn {
+        position: absolute;
+        top: 36px;
+        right: 36px;
+    }
+}

--- a/src/app/shared/components/chat/add-people/add-people.component.spec.ts
+++ b/src/app/shared/components/chat/add-people/add-people.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AddPeopleComponent } from './add-people.component';
+
+describe('AddPeopleComponent', () => {
+  let component: AddPeopleComponent;
+  let fixture: ComponentFixture<AddPeopleComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AddPeopleComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AddPeopleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/chat/add-people/add-people.component.ts
+++ b/src/app/shared/components/chat/add-people/add-people.component.ts
@@ -1,0 +1,15 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { IconLibaryComponent } from "../../icon-component/icon-libary.component";
+import { TranslocoModule } from '@jsverse/transloco';
+
+@Component({
+  selector: 'add-people-overlay',
+  standalone: true,
+  imports: [CommonModule, IconLibaryComponent, TranslocoModule],
+  templateUrl: './add-people.component.html',
+  styleUrl: './add-people.component.scss'
+})
+export class AddPeopleComponent {
+  @Input() curvedEdge: boolean = false;
+}

--- a/src/app/shared/components/icon-component/icon-libary.component.ts
+++ b/src/app/shared/components/icon-component/icon-libary.component.ts
@@ -20,7 +20,7 @@ export class IconLibaryComponent implements AfterContentInit {
   @Input() iconName: IconName = '';
   @Input() iconAlt: string = '';
   @Input() iconClass: string = '';
-  @Input() suffix: string = 'png';
+  @Input() suffix: string = 'svg';
   @Input() round: boolean = false;
   @Input() width: string = '';
   @Input() height: string = '';

--- a/src/app/shared/components/user-avatar/user-avatar.component.html
+++ b/src/app/shared/components/user-avatar/user-avatar.component.html
@@ -1,7 +1,7 @@
 <div class="user-information" role="status" [attr.aria-label]="exampleUser.name + ': ' + onlineStatus.getStatus(exampleUser.lastActivity, exampleUser.isOffline)">
     <div class="avatar">
         <img src="/assets/images/avatars/demo_avatar.png" [ngStyle]="{'height': size+'px', 'width': size+'px'}" draggable="false" alt="">
-        <div class="online-status" [ngClass]="'is-'+onlineStatus.getStatus(exampleUser.lastActivity, exampleUser.isOffline)"></div>
+        <div class="online-status" [ngStyle]="{'width': (size/5)+'px', 'height':(size/5)+'px'}" [ngClass]="'is-'+onlineStatus.getStatus(exampleUser.lastActivity, exampleUser.isOffline)"></div>
     </div>
     @if (!hideUsername) {
         <span aria-hidden="true" class="user-name">{{exampleUser.name}}</span>

--- a/src/app/shared/components/user-avatar/user-avatar.component.scss
+++ b/src/app/shared/components/user-avatar/user-avatar.component.scss
@@ -14,8 +14,6 @@
         position: absolute;
         bottom: 0;
         right: 0;
-        width: 16px;
-        height: 16px;
         border: 2px solid $colorBG;
         border-radius: 50%;
         &.is-online {

--- a/src/app/shared/scss/_icons.scss
+++ b/src/app/shared/scss/_icons.scss
@@ -9,7 +9,7 @@
 }
 
 .icon--hoverable {
-    @include dflex();
+    @include dflex(center, center);
     height: 40px;
     width: 40px;
     cursor: pointer;


### PR DESCRIPTION
in user-avatar the standard-size of the dot was set by a 70x70px avatar and doesn't fit for smaller ones. now the size of the dot is allways a fifth of avatar size, which should work proper in every size